### PR TITLE
Enable parameter-aware tool approval

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "A self-hostable AI assistant with web UI, Discord bot, scheduled 
 license = "MIT"
 
 [dependencies]
-orra = { git = "https://github.com/jereanon/orra.git", rev = "e74c8f3", features = [
+orra = { git = "https://github.com/jereanon/orra.git", rev = "a5b3624", features = [
     "claude",
     "openai",
     "discord",


### PR DESCRIPTION
## Summary
- Bumps orra to rev with `ApprovalRequirement` enum (`Never`, `UnlessAutoApproved`, `Always`) and `RequirementLookup` callback on `ApprovalHook`
- Tools can now override `approval_requirement(&self, args)` to declare per-call approval levels based on arguments

Closes #9