### PR TITLE
Add lightweight mode for cron jobs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "A self-hostable AI assistant with web UI, Discord bot, scheduled 
 license = "MIT"
 
 [dependencies]
-orra = { git = "https://github.com/jereanon/orra.git", rev = "e74c8f3", features = [
+orra = { git = "https://github.com/jereanon/orra.git", rev = "a5b3624", features = [
     "claude",
     "openai",
     "discord",

--- a/src/main.rs
+++ b/src/main.rs
@@ -694,7 +694,15 @@ async fn main() {
                 let ns_key = ns.key();
                 let model = job.model.clone();
                 let max_turns = job.max_turns;
-                match rt.run_with_model(&ns, Message::user(&prompt), model, max_turns).await {
+                let is_lightweight = job.lightweight.unwrap_or(false);
+
+                let run_result = if is_lightweight {
+                    hlog!("[cron] Running job '{}' in lightweight mode", job.name);
+                    rt.run_lightweight(&ns, Message::user(&prompt), model).await
+                } else {
+                    rt.run_with_model(&ns, Message::user(&prompt), model, max_turns).await
+                };
+                match run_result {
                     Ok(result) => {
                         hlog!(
                             "[cron] Job '{}' completed ({} turns)",

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -1429,6 +1429,7 @@ pub struct CreateCronJobRequest {
     pub model: Option<String>,
     pub max_turns: Option<usize>,
     pub auto_approve: Option<bool>,
+    pub lightweight: Option<bool>,
 }
 
 fn default_namespace() -> String {
@@ -1492,6 +1493,7 @@ pub async fn create_cron_job(
     job.model = request.model;
     job.max_turns = request.max_turns;
     job.auto_approve = request.auto_approve;
+    job.lightweight = request.lightweight;
     match svc.add_job(job).await {
         Ok(job) => (StatusCode::CREATED, Json(serde_json::json!(job))).into_response(),
         Err(e) => (
@@ -1614,6 +1616,7 @@ pub struct UpdateCronJobRequest {
     pub model: Option<String>,
     pub max_turns: Option<usize>,
     pub auto_approve: Option<bool>,
+    pub lightweight: Option<bool>,
 }
 
 pub async fn update_cron_job(
@@ -1674,6 +1677,7 @@ pub async fn update_cron_job(
     job.model = request.model;
     job.max_turns = request.max_turns;
     job.auto_approve = request.auto_approve;
+    job.lightweight = request.lightweight;
     if let Some(ref schedule_val) = request.schedule {
         match parse_schedule_from_json(schedule_val) {
             Ok(s) => {

--- a/src/web/static/index.html
+++ b/src/web/static/index.html
@@ -1779,6 +1779,10 @@
                             <input type="checkbox" id="cronAutoApprove" style="accent-color:var(--accent);cursor:pointer;width:16px;height:16px">
                             <label for="cronAutoApprove" style="cursor:pointer;margin:0;font-weight:normal">Auto-approve tools</label>
                         </div>
+                        <div class="settings-field" style="display:flex;align-items:center;gap:8px;padding-top:22px">
+                            <input type="checkbox" id="cronLightweight" style="accent-color:var(--accent);cursor:pointer;width:16px;height:16px">
+                            <label for="cronLightweight" style="cursor:pointer;margin:0;font-weight:normal">Lightweight (no tools)</label>
+                        </div>
                     </div>
                     <div class="settings-actions">
                         <button class="settings-btn" onclick="createCronJob()">Create</button>
@@ -4269,6 +4273,7 @@
                         <span>Channel: ${escapeHtml(resolveChannelName(job.namespace))}</span>
                         ${job.max_turns ? `<span>Max turns: ${job.max_turns}</span>` : ''}
                         ${job.auto_approve ? '<span>Auto-approve</span>' : ''}
+                        ${job.lightweight ? '<span>Lightweight</span>' : ''}
                         <span>Next: ${nextRun}</span>
                         <span>Runs: ${job.run_count}</span>
                     </div>
@@ -4398,6 +4403,10 @@
                         <input type="checkbox" id="editCronAutoApprove-${id}" ${job.auto_approve ? 'checked' : ''} style="accent-color:var(--accent);cursor:pointer;width:16px;height:16px">
                         <label for="editCronAutoApprove-${id}" style="cursor:pointer;margin:0;font-weight:normal">Auto-approve tools</label>
                     </div>
+                    <div class="settings-field" style="display:flex;align-items:center;gap:8px;padding-top:22px">
+                        <input type="checkbox" id="editCronLightweight-${id}" ${job.lightweight ? 'checked' : ''} style="accent-color:var(--accent);cursor:pointer;width:16px;height:16px">
+                        <label for="editCronLightweight-${id}" style="cursor:pointer;margin:0;font-weight:normal">Lightweight (no tools)</label>
+                    </div>
                 </div>
                 <div class="settings-actions">
                     <button class="settings-btn" onclick="saveCronJob('${id}')">Save</button>
@@ -4477,6 +4486,8 @@
                 const updateBody = { name, schedule, payload, namespace: namespace || 'web', model: editModel };
                 if (!isNaN(editMaxTurns) && editMaxTurns > 0) updateBody.max_turns = editMaxTurns;
                 if (editAutoApprove) updateBody.auto_approve = true;
+                const editLightweight = document.getElementById(`editCronLightweight-${id}`).checked;
+                if (editLightweight) updateBody.lightweight = true;
 
                 const resp = await fetch(`/api/cron/${encodeURIComponent(id)}`, {
                     method: 'PUT',
@@ -4584,6 +4595,7 @@
                 const maxTurns = parseInt(document.getElementById('cronMaxTurns').value, 10);
                 if (!isNaN(maxTurns) && maxTurns > 0) createBody.max_turns = maxTurns;
                 if (document.getElementById('cronAutoApprove').checked) createBody.auto_approve = true;
+                if (document.getElementById('cronLightweight').checked) createBody.lightweight = true;
 
                 const resp = await fetch('/api/cron', {
                     method: 'POST',


### PR DESCRIPTION
## Summary
- Adds `lightweight` flag to cron jobs: single LLM call, no tools
- Uses orra's `run_lightweight()` for cheap triage tasks
- Exposed in both create and edit UI with a checkbox

Closes #14