### PR TITLE
Add cheap_model for lightweight tasks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "A self-hostable AI assistant with web UI, Discord bot, scheduled 
 license = "MIT"
 
 [dependencies]
-orra = { git = "https://github.com/jereanon/orra.git", rev = "e74c8f3", features = [
+orra = { git = "https://github.com/jereanon/orra.git", rev = "a5b3624", features = [
     "claude",
     "openai",
     "discord",

--- a/src/config.rs
+++ b/src/config.rs
@@ -180,6 +180,9 @@ pub struct ProviderConfig {
     pub api_key: Option<String>,
     #[serde(default = "default_model")]
     pub model: String,
+    /// Optional cheap/fast model for lightweight tasks (e.g. cron triage).
+    /// Falls back to `model` if not set.
+    pub cheap_model: Option<String>,
     #[serde(default = "default_max_tokens")]
     pub max_tokens: u32,
     #[serde(default = "default_temperature")]
@@ -196,6 +199,7 @@ impl Default for ProviderConfig {
         Self {
             api_key: None,
             model: default_model(),
+            cheap_model: None,
             max_tokens: default_max_tokens(),
             temperature: default_temperature(),
             provider_type: default_provider_type(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -602,6 +602,7 @@ async fn main() {
         let events_tx = session_events_tx.clone();
         let cron_interactive = interactive_count.clone();
         let cron_store = store.clone();
+        let cron_cheap_model = config.provider.cheap_model.clone();
         let cron_callback: orra::cron::service::CronCallback = Arc::new(move |job| {
             let rts = cron_runtimes.clone();
             let fallback_rt = cron_fallback_rt.clone();
@@ -609,6 +610,7 @@ async fn main() {
             let events_tx = events_tx.clone();
             let interactive = cron_interactive.clone();
             let store = cron_store.clone();
+            let cheap_model = cron_cheap_model.clone();
             tokio::spawn(async move {
                 let raw_prompt = match &job.payload {
                     CronPayload::AgentTurn { prompt } => prompt.clone(),
@@ -692,7 +694,12 @@ async fn main() {
                     ns.key()
                 );
                 let ns_key = ns.key();
-                let model = job.model.clone();
+                // For lightweight jobs, prefer cheap_model if configured
+                let model = if job.lightweight.unwrap_or(false) {
+                    job.model.clone().or(cheap_model.clone())
+                } else {
+                    job.model.clone()
+                };
                 let max_turns = job.max_turns;
                 match rt.run_with_model(&ns, Message::user(&prompt), model, max_turns).await {
                     Ok(result) => {


### PR DESCRIPTION
## Summary
- Adds `cheap_model` field to provider config for lightweight operations
- Lightweight cron jobs automatically use the cheap model (e.g. Haiku) when configured
- Falls back to the main model if `cheap_model` is not set

Closes #11