### PR TITLE
Replace string literals with typed enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "A self-hostable AI assistant with web UI, Discord bot, scheduled 
 license = "MIT"
 
 [dependencies]
-orra = { git = "https://github.com/jereanon/orra.git", rev = "e74c8f3", features = [
+orra = { git = "https://github.com/jereanon/orra.git", rev = "a5b3624", features = [
     "claude",
     "openai",
     "discord",

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -230,7 +230,7 @@ mod tests {
             agents: Vec::new(),
             discord: DiscordConfig {
                 token: Some("tok".into()),
-                filter: "mentions".into(),
+                filter: crate::config::DiscordFilter::Mentions,
                 namespace_prefix: "discord".into(),
                 allowed_users: Vec::new(),
             },
@@ -239,7 +239,7 @@ mod tests {
                 model: "claude-opus-4-6".into(),
                 max_tokens: 4096,
                 temperature: 0.7,
-                provider_type: "claude".into(),
+                provider_type: crate::config::ProviderType::Claude,
                 api_url: None,
             },
             tools: ToolsConfig::default(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,8 +192,8 @@ async fn main() {
             auth_source = "config".to_string();
         }
 
-        let real_provider: Arc<dyn Provider> = match config.provider.provider_type.as_str() {
-            "openai" => {
+        let real_provider: Arc<dyn Provider> = match config.provider.provider_type {
+            config::ProviderType::OpenAI => {
                 let mut p = OpenAIProvider::new(api_key, &config.provider.model);
                 if let Some(ref url) = config.provider.api_url {
                     p = p.with_api_url(url);
@@ -204,7 +204,7 @@ async fn main() {
                 );
                 Arc::new(p)
             }
-            _ => {
+            config::ProviderType::Claude => {
                 hlog!(
                     "[init] provider: claude ({}) [source: {}]",
                     config.provider.model, auth_source
@@ -235,15 +235,15 @@ async fn main() {
     hlog!("[init] data directory: {}", config.data_dir.display());
 
     // --- Session store ---
-    let store: Arc<dyn orra::store::SessionStore> = match config.sessions.store.as_str() {
-        "file" => {
+    let store: Arc<dyn orra::store::SessionStore> = match config.sessions.store {
+        config::SessionStoreType::File => {
             hlog!(
                 "[init] session store: file ({})",
                 sessions_path.display()
             );
             Arc::new(FileStore::new(&sessions_path))
         }
-        _ => {
+        config::SessionStoreType::Memory => {
             hlog!("[init] session store: in-memory");
             Arc::new(InMemoryStore::new())
         }
@@ -757,7 +757,7 @@ async fn main() {
         match discord_manager
             .connect(
                 discord_token,
-                &config.discord.filter,
+                config.discord.filter,
                 config.discord.allowed_users.clone(),
                 &config.discord.namespace_prefix,
             )
@@ -823,7 +823,7 @@ async fn main() {
         runtime: runtime.clone(),
         store: store.clone(),
         dynamic_provider: dynamic_provider.clone(),
-        config_provider_type: config.provider.provider_type.clone(),
+        config_provider_type: config.provider.provider_type,
         config_model: config.provider.model.clone(),
         config_api_url: config.provider.api_url.clone(),
         auth_source: Arc::new(tokio::sync::RwLock::new(auth_source.clone())),

--- a/src/web.rs
+++ b/src/web.rs
@@ -48,7 +48,7 @@ pub struct AppState {
     /// The dynamic provider, allowing hot-swap at runtime via POST /api/config.
     pub dynamic_provider: Arc<DynamicProvider>,
     /// Default provider type from config (used when creating providers at runtime).
-    pub config_provider_type: String,
+    pub config_provider_type: crate::config::ProviderType,
     /// Default model from config.
     pub config_model: String,
     /// Custom API URL from config (for OpenAI-compatible endpoints).


### PR DESCRIPTION
Introduces `ProviderType`, `DiscordFilter`, and `SessionStoreType` enums, replacing raw string comparisons for provider type, Discord filter mode, and session store type across the codebase. Invalid values are now caught at deserialization time by serde instead of manual validation.

Closes #12